### PR TITLE
core: fixup null termination in server_method_create

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -106,7 +106,8 @@ const rtPrivateClientInfo* _rbuscore_find_server_privateconnection(const char *p
 void server_method_create(server_method_t* meth, char const* name, rbus_callback_t callback, void* data)
 {
     (*meth) = rt_malloc(sizeof(struct _server_method));
-    strcpy((*meth)->name, name);
+    strncpy((*meth)->name, name, sizeof((*meth)->name) - 1);
+    (*meth)->name[sizeof((*meth)->name) - 1] = '\0'; 
     (*meth)->callback = callback;
     (*meth)->data = data;
 }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. This changes a `strcpy` call to `strncpy` and adds an explicit null termination in case the `strncpy` call hits its limit. Note that `(*meth)->name` is an array of known length so the use of `sizeof` is valid.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>