### PR TITLE
rbuscore: fixup null termination in configure_router_address

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -576,7 +576,8 @@ static void configure_router_address()
                     if(idx2-idx1 > 0)
                     {
                         buff[idx2] = 0;
-                        strcpy(g_daemon_address, &buff[idx1]);
+                        strncpy(g_daemon_address, &buff[idx1], sizeof(g_daemon_address) - 1);
+                        g_daemon_address[sizeof(g_daemon_address) - 1] = '\0';
                         break;
                     }
                 }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. This replaces a call to `strcpy` with `strncpy`, then explicitly null terminates the destination buffer to handle the case where `strncpy` may hit its limit. Note that `g_daemon_address` is a fixed array of known size.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>