### PR TITLE
rtmessage: check return value of setsockopt

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -1690,7 +1690,10 @@ rtRouted_AcceptClientConnection(rtListener* listener)
   }
   
   uint32_t one = 1;
-  setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one));
+  if (setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one)) == -1)
+  {
+    rtLog_Warn("setsockopt:%s", rtStrError(errno));
+  }
 
   rtRouted_RegisterNewClient(fd, &remote_endpoint);
 }


### PR DESCRIPTION
This code was automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. This change checks the return value of `setsockopt` and logs a warning message in the case that `TCP_NODELAY` cannot be set.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>