### PR TITLE
core: fixup null termination in client_subscription_create

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -302,7 +302,8 @@ int client_subscription_compare(const void* left, const void* right)
 void client_subscription_create(client_subscription_t* sub, const char * object_name)
 {
     (*sub) = rt_malloc(sizeof(struct _client_subscription));
-    strcpy((*sub)->object, object_name);
+    strncpy((*sub)->object, object_name, sizeof((*sub)->object) - 1);
+    (*sub)->object[sizeof((*sub)->object) - 1] = '\0';
     rtVector_Create(&(*sub)->events); 
 }
 


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. This changes a call from `strncpy` and explicitly null-terminates the destination buffer to handle the case where `strncpy` may hit its limit. Note that `(*sub)->object` is an array of known size, so the use of `sizeof` is appropriate.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>