### PR TITLE
rtrouted: fixup null termination in prep_reply_header

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -19,6 +19,7 @@
 ##########################################################################
 */
 #include "rtMessage.h"
+#include "safec_lib.h"
 #include "rtTime.h"
 #include "rtCipher.h"
 #include "rtDebug.h"
@@ -721,8 +722,10 @@ static void prep_reply_header_from_request(rtMessageHeader *reply, const rtMessa
   reply->sequence_number = request->sequence_number;
   reply->flags = rtMessageFlags_Response;
 
-  strncpy(reply->topic, request->reply_topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
-  strncpy(reply->reply_topic, request->topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
+  errno_t rc = strncpy_s(reply->topic, RTMSG_HEADER_MAX_TOPIC_LENGTH, request->reply_topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
+  ERR_CHK(rc);
+  rc = strncpy_s(reply->reply_topic, RTMSG_HEADER_MAX_TOPIC_LENGTH, request->topic, RTMSG_HEADER_MAX_TOPIC_LENGTH-1);
+  ERR_CHK(rc);
   reply->topic_length = request->reply_topic_length;
   reply->reply_topic_length = request->topic_length;
 #ifdef MSG_ROUNDTRIP_TIME


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese, @fwph, and @eelenberg. This is an example of the use of safeclib's `*_s` functions to replace misuses of other string functions. In this case, `strncpy` is used without null terminating, which could leave an unterminated string if the call to `strncpy` were to hit its limit. This change uses `strncpy_s` which detects potential overflow and sets the destination to the empty string in that case.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>