### PR TITLE
rbus: fixup variable shadow in properyList_InitFromMessage

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -661,16 +661,16 @@ void rbusPropertyList_initFromMessage(rbusProperty_t* prop, rbusMessage msg)
 #endif
     while(--numProps >= 0)
     {
-        rbusProperty_t prop;
-        rbusProperty_initFromMessage(&prop, msg);
+        rbusProperty_t current;
+        rbusProperty_initFromMessage(&current, msg);
         if(first == NULL)
-            first = prop;
+            first = current;
         if(previous != NULL)
         {
-            rbusProperty_SetNext(previous, prop);
-            rbusProperty_Release(prop);
+            rbusProperty_SetNext(previous, current);
+            rbusProperty_Release(current);
         }
-        previous = prop;
+        previous = current;
     }
     /*TODO we need to release the props we inited*/
     *prop = first;


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. The property being initialized from the message inside the loop is named `prop`, shadowing the name of the eventual output variable. This simply renames the inner variable to `current`.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>