### PR TITLE
rtHashMap: fixup potential division by zero

### DIFF
--- a/src/rtmessage/rtHashMap.c
+++ b/src/rtmessage/rtHashMap.c
@@ -234,7 +234,8 @@ void rtHashMap_Set(rtHashMap hashmap, const void* key, const void* value)
     }
     if(!node)
     {
-        if((hashmap->size+1) / (float)rtVector_Size(hashmap->buckets) > hashmap->load_factor)
+        size_t bucketSize = rtVector_Size(hashmap->buckets);
+        if(bucketSize != 0 && (hashmap->size+1) / (float)bucketSize > hashmap->load_factor)
         {
             rtHashMap_Resize(hashmap, 1);
             bucket = rtHashMap_GetBucket(hashmap, key);
@@ -295,6 +296,8 @@ uint32_t rtHashMap_Hash_Func_String(rtHashMap hashmap, const void* key)
         hash = hash * 31 + *skey;
         skey++;
     }
+    if(rtVector_Size(hashmap->buckets) == 0)
+        return 0;
     return abs(hash) % rtVector_Size(hashmap->buckets);
 }
 


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese, @fwph, and @josephhackman. In the rare case that an `rtHashMap` contains no buckets, the calculation of its load factor would cause a divide by zero. Similarly, calling `Hash_Func_String` using a map with no buckets would take a value modulo zero, which is also UB.

In the hash function, we guard this and return the hash value zero in that case. It is a valid hash value, and in practice, its use in `GetBucket` is already guarded by a check on the size of `buckets`.

In the load factor calculation, if the number of buckets were zero, the attempted resize would be a noop anyway (since the new number of buckets is just calculated by doubling the old number).

on-behalf-of: @permanence-ai <github-ai@permanence.ai>