### PR TITLE
rbuscli: check for null pointer when constructing cmds

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -2589,6 +2589,11 @@ int handle_cmds (int argc, char *argv[])
 
 static int construct_input_into_cmds(char* buff, int* pargc, char** argv)
 {
+    if (buff == NULL || pargc == NULL || argv == NULL)
+    {
+        return -1;
+    }
+
     int len = (int)strlen(buff);
     int i, j, quote;
     int argc = 0;


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. Here, each of `buff`, `argv`, and `pargc` are being dereferenced without checking whether they are null. This adds an explicit check.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>