### PR TITLE
rbuscli: fixup leak in validate_and_execute_subscribe_cmd

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -2071,6 +2071,10 @@ void validate_and_execute_subscribe_cmd (int argc, char *argv[], bool add, bool 
 exit_error:
         runSteps = __LINE__;
         printf ("Invalid arguments. Please see the help\r\n");
+        if (filterValue)
+            rbusValue_Release(filterValue);
+        if (filter)
+            rbusFilter_Release(filter);
         rt_free(userData);
         return;
     }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. The `exit_error` block returns early, but it could have been jumped to from points where `filter` and `filterValue` were already allocated. This releases both variables before the early return.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>