### PR TITLE
rtrouted: fixup potential null dereference

### DIFF
--- a/src/rtmessage/rtrouted.c
+++ b/src/rtmessage/rtrouted.c
@@ -223,7 +223,10 @@ rtRouted_ReadTextFile(char const* fname, char** content)
       rtLog_Error("failed to read file %s. %s", fname, strerror(errno));
       err = RT_FAIL;
     }
-    (*content)[sz] = 0;
+    else
+    {
+      (*content)[sz] = 0;
+    }
     fclose(pf);
   }
   else


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. In the case of a short read, the original code frees `*content` and sets it to null, but in that case, after the if block, it still tries to null-terminate by assigning to `(*content)[sz]`. This change moves that assignment to an else block where `*content` is valid and contains data of length `sz`.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>