### PR TITLE
rbuscore: initialize privConsInfo

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -2811,7 +2811,7 @@ rbusCoreError_t rbuscore_startPrivateListener(const char* pPrivateConnAddress, c
     rbusServerDMLList_t *obj = NULL;
     int err = 0;
     pthread_t pid;
-    rtPrivateClientInfo  privConsInfo;
+    rtPrivateClientInfo privConsInfo = {0};
 
     if (pDMLName && pPrivateConnAddress && handler)
     {


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. In the case where `obj` does not exist, `pTemp->m_consumerInfo` will be `memcpy`'d from an uninitialized `privConsInfo`. This change zero-initializes `privConsInfo` at declaration time instead.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>