### PR TITLE
rbus: check return value for remove

### DIFF
--- a/src/rbus/rbus.c
+++ b/src/rbus/rbus.c
@@ -17,6 +17,7 @@
  * limitations under the License.
 */
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -3176,7 +3177,9 @@ rbusError_t rbus_close(rbusHandle_t handle)
     LockMutex();
     char filename[RTMSG_HEADER_MAX_TOPIC_LENGTH];
     snprintf(filename, RTMSG_HEADER_MAX_TOPIC_LENGTH-1, "%s%d_%d", "/tmp/.rbus/", getpid(), handleInfo->componentId);
-    remove(filename);
+    if (remove(filename) != 0) {
+        RBUSLOG_ERROR("Error removing file: %s (errno: %d)", filename, errno);
+    }
 
     HANDLE_EVENTSUBS_MUTEX_LOCK(handle);
     if(handleInfo->eventSubs)


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. This explicitly checks the return value of the `remove` call and logs an error in case the file could not be removed.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>