### PR TITLE
rbus_tokenchain: add missing initializer

### DIFF
--- a/src/rbus/rbus_tokenchain.c
+++ b/src/rbus/rbus_tokenchain.c
@@ -254,7 +254,7 @@ bool TokenChain_match(TokenChain* chain, elementNode* instNode)
         return false;
     Token* token = chain->last;
     elementNode* inst = instNode;
-    int rc;
+    int rc = 0;
 
 #   if DEBUG_TOKEN
     RBUSLOG_INFO("%s DEBUG: instNode=%s tokenChain=", __FUNCTION__, instNode->fullName);


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. There is a chance that `rc` could be used without initialization, so this change explicitly initializes it to zero.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>