### PR TITLE
rtmessage: check return value of setsockopt

### DIFF
--- a/src/rtmessage/rtrouteBase.c
+++ b/src/rtmessage/rtrouteBase.c
@@ -503,7 +503,10 @@ rtRouteDirect_AcceptClientConnection(rtListener* listener)
   }
   
   uint32_t one = 1;
-  setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one));
+  if (setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one)) == -1)
+  {
+    rtLog_Warn("setsockopt:%s", rtStrError(errno));
+  }
 
   return rtRouteDirect_RegisterNewClient(fd, &remote_endpoint);
 }


### PR DESCRIPTION
The changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @eelenberg, @fwph, and @jweese. This checks the return value of `setsockopt` and logs a warning message if it fails.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>