### PR TITLE
core: use safeclib in server_object_create

### DIFF
--- a/src/core/rbuscore.c
+++ b/src/core/rbuscore.c
@@ -33,6 +33,7 @@
 #include "rtMemory.h"
 #include "rtString.h"
 #include "rtrouteBase.h"
+#include "safec_lib.h"
 void rbusMessage_BeginMetaSectionWrite(rbusMessage message);
 void rbusMessage_EndMetaSectionWrite(rbusMessage message);
 void rbusMessage_BeginMetaSectionRead(rbusMessage message);
@@ -192,7 +193,8 @@ int server_object_compare(const void* left, const void* right)
 void server_object_create(server_object_t* obj, char const* name, rbus_callback_t callback, void* data)
 {
     (*obj) = rt_malloc(sizeof(struct _server_object));
-    strcpy((*obj)->name, name);
+    errno_t rc = strcpy_s((*obj)->name, sizeof((*obj)->name), name);
+    ERR_CHK(rc);
     (*obj)->callback = callback;
     (*obj)->data = data;
     (*obj)->process_event_subscriptions = false;


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese, @fwph and @eelenberg. This changes the `strcpy` call to use `strcpy_s` provided by the SafeC library. Here `(*obj)->name` is an array of known size so the use of `sizeof` is valid.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>