### PR TITLE
rbuscli: use safeclib in completion function

### DIFF
--- a/utils/rbuscli/rbuscli.c
+++ b/utils/rbuscli/rbuscli.c
@@ -35,6 +35,7 @@
 #include <rbuscore.h>
 #include <signal.h>
 #include <fcntl.h>
+#include "safec_lib.h"
 #if (__linux__ && __GLIBC__ && !__UCLIBC__) || __APPLE__
   #include <execinfo.h>
 #endif
@@ -2666,10 +2667,12 @@ void completion(const char *buf, linenoiseCompletions *lc) {
     int num = 0;
     char* tokens[3];/*3 or the number of tokens we scan for below*/
     char* completion = NULL;
+    errno_t rc = -1;
 
     len = strlen(buf);
     line = rt_malloc(len + 32);/*32 or just enough room to append a word from below*/
-    strcpy(line, buf);
+    rc = strcpy_s(line, len + 32, buf);
+    ERR_CHK(rc);
   
     tok = strtok_r(cpy, " ", &saveptr);
     while(tok && num < 3)
@@ -2721,7 +2724,8 @@ void completion(const char *buf, linenoiseCompletions *lc) {
 
     if(completion)
     {
-        strcat(line, completion);
+        rc = strcat_s(line, len + 32, completion);
+        ERR_CHK(rc);
         linenoiseAddCompletion(lc, line);
     }
 


### PR DESCRIPTION
The code changes in this PR were automatically generated by the Permanence AI Coder and reviewed by @jweese and @fwph. Here we replace two functions with safer versions from the SafeC library. The initial `strcpy` of `buf` into `line` was replaced with `strcpy_s`. The length is known from the allocation just above. Later, the `strcat` of `line` with `completion` was replaced with `strcat_s`. In each case, the `ERR_CHK` macro was used to verify that no runtime constraint violations occurred.

on-behalf-of: @permanence-ai <github-ai@permanence.ai>