### PR TITLE
rtConnection: free mutexes on early return (revised)

### DIFF
--- a/src/rtmessage/rtConnection.c
+++ b/src/rtmessage/rtConnection.c
@@ -516,6 +516,28 @@ rtConnection_ReadUntil(rtConnection con, uint8_t* buff, int count, int32_t timeo
 }
 
 
+static void
+rtConnection_DestroyOnFailure(rtConnection c, pthread_mutexattr_t* mutex_attribute)
+{
+  pthread_mutex_destroy(&c->mutex);
+  pthread_mutex_destroy(&c->callback_message_mutex);
+  pthread_mutex_destroy(&c->reconnect_mutex);
+  pthread_cond_destroy(&c->callback_message_cond);
+  if (c->send_buffer)
+    free(c->send_buffer);
+  if (c->recv_buffer)
+    free(c->recv_buffer);
+  if (c->application_name)
+    free(c->application_name);
+  if (c->pending_requests_list)
+    rtList_Destroy(c->pending_requests_list, NULL);
+  if (c->callback_message_list)
+    rtList_Destroy(c->callback_message_list, NULL);
+  if (mutex_attribute)
+    pthread_mutexattr_destroy(mutex_attribute);
+  free(c);
+}
+
 static rtError
 rtConnection_CreateInternal(rtConnection* con, char const* application_name, char const* router_config, int max_retries)
 {
@@ -552,24 +574,13 @@ rtConnection_CreateInternal(rtConnection* con, char const* application_name, cha
   c->send_buffer = (uint8_t *) rt_try_malloc(RTMSG_SEND_BUFFER_SIZE);
   if(!c->send_buffer)
   {
-    pthread_mutex_destroy(&c->mutex);
-    pthread_mutex_destroy(&c->callback_message_mutex);
-    pthread_mutex_destroy(&c->reconnect_mutex);
-    pthread_cond_destroy(&c->callback_message_cond);
-    pthread_mutexattr_destroy(&mutex_attribute);
-    free(c);
+    rtConnection_DestroyOnFailure(c, &mutex_attribute);
     return rtErrorFromErrno(ENOMEM);
   }
   c->recv_buffer = (uint8_t *) rt_try_malloc(RTMSG_SEND_BUFFER_SIZE);
   if(!c->recv_buffer)
   {
-    pthread_mutex_destroy(&c->mutex);
-    pthread_mutex_destroy(&c->callback_message_mutex);
-    pthread_mutex_destroy(&c->reconnect_mutex);
-    pthread_cond_destroy(&c->callback_message_cond);
-    free(c->send_buffer);
-    pthread_mutexattr_destroy(&mutex_attribute);
-    free(c);
+    rtConnection_DestroyOnFailure(c, &mutex_attribute);
     return rtErrorFromErrno(ENOMEM);
   }
   c->recv_buffer_capacity = RTMSG_SEND_BUFFER_SIZE;
@@ -605,17 +616,7 @@ rtConnection_CreateInternal(rtConnection* con, char const* application_name, cha
   if (err != RT_OK)
   {
     rtLog_Warn("failed to parse:%s. %s", router_config, rtStrError(err));
-    pthread_mutex_destroy(&c->mutex);
-    pthread_mutex_destroy(&c->callback_message_mutex);
-    pthread_mutex_destroy(&c->reconnect_mutex);
-    pthread_cond_destroy(&c->callback_message_cond);
-    free(c->send_buffer);
-    free(c->recv_buffer);
-    free(c->application_name);
-    rtList_Destroy(c->pending_requests_list,NULL);
-    rtList_Destroy(c->callback_message_list, NULL);
-    pthread_mutexattr_destroy(&mutex_attribute);
-    free(c);
+    rtConnection_DestroyOnFailure(c, &mutex_attribute);
     return err;
   }
   err = rtConnection_ConnectAndRegister(c, 0);
@@ -623,17 +624,7 @@ rtConnection_CreateInternal(rtConnection* con, char const* application_name, cha
   {
     // TODO: at least log this
     rtLog_Warn("rtConnection_ConnectAndRegister(1):%d", err);
-    pthread_mutex_destroy(&c->mutex);
-    pthread_mutex_destroy(&c->callback_message_mutex);
-    pthread_mutex_destroy(&c->reconnect_mutex);
-    pthread_cond_destroy(&c->callback_message_cond);
-    free(c->send_buffer);
-    free(c->recv_buffer);
-    free(c->application_name);
-    rtList_Destroy(c->pending_requests_list,NULL);
-    rtList_Destroy(c->callback_message_list, NULL);
-    pthread_mutexattr_destroy(&mutex_attribute);
-    free(c);
+    rtConnection_DestroyOnFailure(c, &mutex_attribute);
   }
 
   if (err == RT_OK)


### PR DESCRIPTION
The code changes in this PR were automatically generated by the
Permanence AI Coder and reviewed by @jweese and @fwph. On early returns
(such as where `c->send_buffer` or `c->recv_buffer` are not valid, this
function is careful to free the `rtConnection c`. But after that free,
any member variables of `c` aren't reachable and therefore leak. This
change makes appropriate calls to `pthread_mutex_destroy`,
`pthread_cond_destroy` and `pthread_mutexattr_destroy` to release the
initialized member variables when returning on error.

on-behalf-of: https://github.com/permanence-ai <github-ai@permanence.ai>